### PR TITLE
Fix interaction between NeverCall and ExpectCall

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -4276,6 +4276,15 @@ public:
 
   void DoVoidExpectation(base_mock *mock, std::pair<int, int> funcno, const base_tuple &tuple, bool makeLatent = false)
   {
+    for (std::list<Call *>::reverse_iterator i = expectations.rbegin(); i != expectations.rend(); ++i)
+    {
+      Call *call = *i;
+      if ( isUnsatisfied( call, mock, funcno, tuple ) )
+      {
+        doVoidCall( call, tuple, makeLatent );
+        return;
+      }
+    }
     for (std::list<Call *>::reverse_iterator i = neverCalls.rbegin(); i != neverCalls.rend(); ++i)
     {
       Call *call = *i;
@@ -4283,15 +4292,6 @@ public:
       {
          doThrow( call, makeLatent );
          return;
-      }
-    }
-     for (std::list<Call *>::reverse_iterator i = expectations.rbegin(); i != expectations.rend(); ++i)
-    {
-      Call *call = *i;
-      if ( isUnsatisfied( call, mock, funcno, tuple ) )
-      {
-        doVoidCall( call, tuple, makeLatent );
-        return;
       }
     }
     for (std::list<Call *>::reverse_iterator i = optionals.rbegin(); i != optionals.rend(); ++i)
@@ -6348,6 +6348,14 @@ TCall<Y,A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P> &MockRepository::RegisterExpect_(Z2 *mc
 template <typename Z>
 Z MockRepository::DoExpectation(base_mock *mock, std::pair<int, int> funcno, const base_tuple &tuple)
 {
+  for (std::list<Call *>::reverse_iterator i = expectations.rbegin(); i != expectations.rend(); ++i)
+  {
+    Call *call = *i;
+    if( isUnsatisfied( call, mock, funcno, tuple ) )
+    {
+      return doReturnCall<Z>( call, tuple );
+    }
+  }
   for (std::list<Call *>::reverse_iterator i = neverCalls.rbegin(); i != neverCalls.rend(); ++i)
   {
     Call *call = *i;
@@ -6355,14 +6363,6 @@ Z MockRepository::DoExpectation(base_mock *mock, std::pair<int, int> funcno, con
     {
       call->satisfied = true;
       RAISEEXCEPTION(ExpectationException(this, call->getArgs(), call->funcName));
-    }
-  }
-   for (std::list<Call *>::reverse_iterator i = expectations.rbegin(); i != expectations.rend(); ++i)
-  {
-    Call *call = *i;
-    if( isUnsatisfied( call, mock, funcno, tuple ) )
-    {
-      return doReturnCall<Z>( call, tuple );
     }
   }
   for (std::list<Call *>::reverse_iterator i = optionals.rbegin(); i != optionals.rend(); ++i)

--- a/HippoMocksTest/target_cfuncs.c
+++ b/HippoMocksTest/target_cfuncs.c
@@ -14,3 +14,12 @@ int ret_2(void)
     return 2;
 }
 
+void ret_3(void)
+{
+    void_test = 3;
+}
+
+void ret_4(void)
+{
+    void_test = 4;
+}

--- a/HippoMocksTest/target_cfuncs.h
+++ b/HippoMocksTest/target_cfuncs.h
@@ -5,8 +5,12 @@
 extern "C" {
 #endif
 
+extern int void_test;
+
 int ret_1(void);
 int ret_2(void);
+void ret_3(void);
+void ret_4(void);
 
 #ifdef __cplusplus
 }

--- a/HippoMocksTest/test_cfuncs.cpp
+++ b/HippoMocksTest/test_cfuncs.cpp
@@ -5,6 +5,8 @@
 // If it's not supported, then don't test it.
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
+int void_test;
+
 TEST (TestCfuncs, checkFunctionReplacedAndChecked)
 {
 	EXPECT_EQ(ret_2(), 2);

--- a/HippoMocksTest/test_cfuncs_expectcalls.cpp
+++ b/HippoMocksTest/test_cfuncs_expectcalls.cpp
@@ -82,4 +82,20 @@ TEST (TestCfuncsExpectCalls, checkExpectCallsWeaveExpectCallException)
 
     EXPECT_TRUE(exceptionCaught);
 }
+
+
+TEST (TestCfuncsExpectCalls, checkExpectCallOverridesNeverCall) {
+	MockRepository mocks;
+	mocks.NeverCallFunc(ret_1);
+	mocks.ExpectCallFunc(ret_1).Return(3);
+	ret_1();
+}
+
+TEST (TestCfuncsExpectCalls, checkExpectCallOverridesNeverCallVoid) {
+	MockRepository mocks;
+	mocks.NeverCallFunc(ret_3);
+	mocks.ExpectCallFunc(ret_3);
+	ret_3();
+}
+
 #endif

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ TEST(MyTestSuite, MyTestName) {
 ```
 
 ## NeverCall() Method
-Unlike the former two functions, NeverCall() throws an exception if the function you are mocking is ever called.
+Unlike the former two functions, NeverCall() throws an exception if the function you are mocking is ever called. 
 
 ### NeverCallFunc(funcName)
 ``` C++
@@ -160,6 +160,7 @@ TEST(MyTestSuite, MyTestName) {
 }
 ```
 You can further filter the NeverCall() trigger by using the [After() method](#after-method).
+When establishing a mock for a function, ExpectCall() will take priority over NeverCall().
 
 # TCall Class
 The TCall class cannot be instantiated directly. Nevertheless, it useful in order to create conditionals or sequences between mocks that have been instantiated.


### PR DESCRIPTION
[Issue/Feature Description]
The use case of ExpectCall overriding NeverCall is currently unsupported. This is a use case intended to allow for pre-verification of the testing state.

[Resolution]
Swap the check order for ExpectCall and NeverCall so that ExpectCall takes priority.