### PR TITLE
Support mocking interfaces using rvalue references

### DIFF
--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -628,13 +628,13 @@ struct do_assign<T1, T2, false>
 template <typename T1, typename T2>
 void out_assign(T1 a, T2 b)
 {
-  do_assign<T1, T2, IsOutParamType<typename base_type<T1>::type>::value >::assign_to(a, std::forward<T2>(b));
+  do_assign<T1, T2, IsOutParamType<typename base_type<T1>::type>::value >::assign_to(a, b);
 }
 
 template <typename T1, typename T2>
 void in_assign(T1 a, T2 b)
 {
-  do_assign<T1, T2, IsInParamType<typename base_type<T1>::type>::value >::assign_from(a, std::forward<T2>(b));
+  do_assign<T1, T2, IsInParamType<typename base_type<T1>::type>::value >::assign_from(a, b);
 }
 
 template <typename B>

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -4470,7 +4470,7 @@ public:
     return myRepo->template DoExpectation<Y>(realMock, realMock->translateX(X), ref_tuple<>());
   }
   template <int X, typename A>
-  Y expectation1(A&& a)
+  Y expectation1(A a)
   {
     mock<Z> *realMock = mock<Z>::getRealThis();
     if (realMock->isZombie)
@@ -4908,7 +4908,7 @@ public:
     myRepo->DoVoidExpectation(realMock, realMock->translateX(X), ref_tuple<>());
   }
   template <int X, typename A>
-  void expectation1(A&& a)
+  void expectation1(A a)
   {
     mock<Z> *realMock = mock<Z>::getRealThis();
     if (realMock->isZombie)
@@ -6108,7 +6108,7 @@ template <int X, typename Z2, typename Y, typename Z, typename A>
 TCall<Y,A> &MockRepository::RegisterExpect_(Z2 *mck, Y (Z::*func)(A), RegistrationType expect, const char *functionName, const char *fileName, unsigned long lineNo)
 {
   std::pair<int, int> funcIndex = virtual_index((Y(Z2::*)(A))func);
-  Y (mockFuncs<Z2, Y>::*mfp)(A&&);
+  Y (mockFuncs<Z2, Y>::*mfp)(A);
   mfp = &mockFuncs<Z2, Y>::template expectation1<X,A>;
   BasicRegisterExpect(reinterpret_cast<mock<Z2> *>(mck),
             funcIndex.first, funcIndex.second,

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -637,6 +637,19 @@ void in_assign(T1 a, T2 b)
   do_assign<T1, T2, IsInParamType<typename base_type<T1>::type>::value >::assign_from(a, std::forward<T2>(b));
 }
 
+template <typename B>
+struct store_ref
+{
+  typedef B type;
+};
+
+template <typename B>
+struct store_ref<B&&>
+{
+  typedef B& type;
+};
+
+
 template <typename A = NullType, typename B = NullType, typename C = NullType, typename D = NullType,
       typename E = NullType, typename F = NullType, typename G = NullType, typename H = NullType,
       typename I = NullType, typename J = NullType, typename K = NullType, typename L = NullType,
@@ -644,7 +657,7 @@ template <typename A = NullType, typename B = NullType, typename C = NullType, t
 class ref_tuple : public base_tuple
 {
 public:
-  A a;
+  typename store_ref<A>::type a;
   B b;
   C c;
   D d;
@@ -660,8 +673,8 @@ public:
   N n;
   O o;
   P p;
-  ref_tuple(A valueA = A(), B valueB = B(), C valueC = C(), D valueD = D(), E valueE = E(), F valueF = F(), G valueG = G(), H valueH = H(), I valueI = I(), J valueJ = J(), K valueK = K(), L valueL = L(), M valueM = M(), N valueN = N(), O valueO = O(), P valueP = P())
-      : a(std::forward<A>(valueA)), b(valueB), c(valueC), d(valueD), e(valueE), f(valueF), g(valueG), h(valueH), i(valueI), j(valueJ), k(valueK), l(valueL), m(valueM), n(valueN), o(valueO), p(valueP)
+  ref_tuple(typename store_ref<A>::type valueA = A(), B valueB = B(), C valueC = C(), D valueD = D(), E valueE = E(), F valueF = F(), G valueG = G(), H valueH = H(), I valueI = I(), J valueJ = J(), K valueK = K(), L valueL = L(), M valueM = M(), N valueN = N(), O valueO = O(), P valueP = P())
+      : a(valueA), b(valueB), c(valueC), d(valueD), e(valueE), f(valueF), g(valueG), h(valueH), i(valueI), j(valueJ), k(valueK), l(valueL), m(valueM), n(valueN), o(valueO), p(valueP)
   {}
   virtual void printTo(std::ostream &os) const
   {
@@ -773,7 +786,7 @@ public:
   }
   void assign_from(ref_tuple<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P> &from)
   {
-    in_assign< typename store_as<CA>::type, A>(a, std::forward<A>(from.a));
+    in_assign< typename store_as<CA>::type, typename store_ref<A>::type >(a, from.a);
     in_assign< typename store_as<CB>::type, B>(b, from.b);
     in_assign< typename store_as<CC>::type, C>(c, from.c);
     in_assign< typename store_as<CD>::type, D>(d, from.d);
@@ -792,7 +805,7 @@ public:
   }
   void assign_to(ref_tuple<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P> &to)
   {
-    out_assign< typename store_as<CA>::type, A>(a, std::forward<A>(to.a));
+    out_assign< typename store_as<CA>::type, typename store_ref<A>::type>(a, to.a);
     out_assign< typename store_as<CB>::type, B>(b, to.b);
     out_assign< typename store_as<CC>::type, C>(c, to.c);
     out_assign< typename store_as<CD>::type, D>(d, to.d);
@@ -4914,7 +4927,7 @@ public:
     if (realMock->isZombie)
       RAISEEXCEPTION(ZombieMockException(realMock->repo));
     MockRepository *myRepo = realMock->repo;
-    myRepo->DoVoidExpectation(realMock, realMock->translateX(X), ref_tuple<A>(std::forward<A>(a)));
+    myRepo->DoVoidExpectation(realMock, realMock->translateX(X), ref_tuple<A>(a));
   }
   template <int X, typename A, typename B>
   void expectation2(A a, B b)

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -496,7 +496,7 @@ inline std::ostream &operator<<(std::ostream &os, ByRef<T> &ref) {
 template <typename T>
 struct printArg
 {
-  static inline void print(std::ostream &os, T arg, bool withComma)
+  static inline void print(std::ostream &os, const T& arg, bool withComma)
   {
     if (withComma)
       os << ",";
@@ -659,7 +659,7 @@ public:
   O o;
   P p;
   ref_tuple(A valueA = A(), B valueB = B(), C valueC = C(), D valueD = D(), E valueE = E(), F valueF = F(), G valueG = G(), H valueH = H(), I valueI = I(), J valueJ = J(), K valueK = K(), L valueL = L(), M valueM = M(), N valueN = N(), O valueO = O(), P valueP = P())
-      : a(valueA), b(valueB), c(valueC), d(valueD), e(valueE), f(valueF), g(valueG), h(valueH), i(valueI), j(valueJ), k(valueK), l(valueL), m(valueM), n(valueN), o(valueO), p(valueP)
+      : a(std::forward<A>(valueA)), b(valueB), c(valueC), d(valueD), e(valueE), f(valueF), g(valueG), h(valueH), i(valueI), j(valueJ), k(valueK), l(valueL), m(valueM), n(valueN), o(valueO), p(valueP)
   {}
   virtual void printTo(std::ostream &os) const
   {
@@ -4462,13 +4462,13 @@ public:
     return myRepo->template DoExpectation<Y>(realMock, realMock->translateX(X), ref_tuple<>());
   }
   template <int X, typename A>
-  Y expectation1(A a)
+  Y expectation1(A&& a)
   {
     mock<Z> *realMock = mock<Z>::getRealThis();
     if (realMock->isZombie)
       RAISEEXCEPTION(ZombieMockException(realMock->repo));
     MockRepository *myRepo = realMock->repo;
-    return myRepo->template DoExpectation<Y>(realMock, realMock->translateX(X), ref_tuple<A>(a));
+    return myRepo->template DoExpectation<Y>(realMock, realMock->translateX(X), ref_tuple<A>(std::forward<A>(a)));
   }
   template <int X, typename A, typename B>
   Y expectation2(A a, B b)
@@ -4900,13 +4900,13 @@ public:
     myRepo->DoVoidExpectation(realMock, realMock->translateX(X), ref_tuple<>());
   }
   template <int X, typename A>
-  void expectation1(A a)
+  void expectation1(A&& a)
   {
     mock<Z> *realMock = mock<Z>::getRealThis();
     if (realMock->isZombie)
       RAISEEXCEPTION(ZombieMockException(realMock->repo));
     MockRepository *myRepo = realMock->repo;
-    myRepo->DoVoidExpectation(realMock, realMock->translateX(X), ref_tuple<A>(a));
+    myRepo->DoVoidExpectation(realMock, realMock->translateX(X), ref_tuple<A>(std::forward<A>(a)));
   }
   template <int X, typename A, typename B>
   void expectation2(A a, B b)
@@ -6100,7 +6100,7 @@ template <int X, typename Z2, typename Y, typename Z, typename A>
 TCall<Y,A> &MockRepository::RegisterExpect_(Z2 *mck, Y (Z::*func)(A), RegistrationType expect, const char *functionName, const char *fileName, unsigned long lineNo)
 {
   std::pair<int, int> funcIndex = virtual_index((Y(Z2::*)(A))func);
-  Y (mockFuncs<Z2, Y>::*mfp)(A);
+  Y (mockFuncs<Z2, Y>::*mfp)(A&&);
   mfp = &mockFuncs<Z2, Y>::template expectation1<X,A>;
   BasicRegisterExpect(reinterpret_cast<mock<Z2> *>(mck),
             funcIndex.first, funcIndex.second,

--- a/HippoMocks/hippomocks.h
+++ b/HippoMocks/hippomocks.h
@@ -658,22 +658,29 @@ class ref_tuple : public base_tuple
 {
 public:
   typename store_ref<A>::type a;
-  B b;
-  C c;
-  D d;
-  E e;
-  F f;
-  G g;
-  H h;
-  I i;
-  J j;
-  K k;
-  L l;
-  M m;
-  N n;
-  O o;
-  P p;
-  ref_tuple(typename store_ref<A>::type valueA = A(), B valueB = B(), C valueC = C(), D valueD = D(), E valueE = E(), F valueF = F(), G valueG = G(), H valueH = H(), I valueI = I(), J valueJ = J(), K valueK = K(), L valueL = L(), M valueM = M(), N valueN = N(), O valueO = O(), P valueP = P())
+  typename store_ref<B>::type b;
+  typename store_ref<C>::type c;
+  typename store_ref<D>::type d;
+  typename store_ref<E>::type e;
+  typename store_ref<F>::type f;
+  typename store_ref<G>::type g;
+  typename store_ref<H>::type h;
+  typename store_ref<I>::type i;
+  typename store_ref<J>::type j;
+  typename store_ref<K>::type k;
+  typename store_ref<L>::type l;
+  typename store_ref<M>::type m;
+  typename store_ref<N>::type n;
+  typename store_ref<O>::type o;
+  typename store_ref<P>::type p;
+  ref_tuple(typename store_ref<A>::type valueA = A(), typename store_ref<B>::type valueB = B(),
+    typename store_ref<C>::type valueC = C(), typename store_ref<D>::type valueD = D(),
+    typename store_ref<E>::type valueE = E(), typename store_ref<F>::type valueF = F(),
+    typename store_ref<G>::type valueG = G(), typename store_ref<H>::type valueH = H(),
+    typename store_ref<I>::type valueI = I(), typename store_ref<J>::type valueJ = J(),
+    typename store_ref<K>::type valueK = K(), typename store_ref<L>::type valueL = L(),
+    typename store_ref<M>::type valueM = M(), typename store_ref<N>::type valueN = N(),
+    typename store_ref<O>::type valueO = O(), typename store_ref<P>::type valueP = P())
       : a(valueA), b(valueB), c(valueC), d(valueD), e(valueE), f(valueF), g(valueG), h(valueH), i(valueI), j(valueJ), k(valueK), l(valueL), m(valueM), n(valueN), o(valueO), p(valueP)
   {}
   virtual void printTo(std::ostream &os) const
@@ -786,41 +793,41 @@ public:
   }
   void assign_from(ref_tuple<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P> &from)
   {
-    in_assign< typename store_as<CA>::type, typename store_ref<A>::type >(a, from.a);
-    in_assign< typename store_as<CB>::type, B>(b, from.b);
-    in_assign< typename store_as<CC>::type, C>(c, from.c);
-    in_assign< typename store_as<CD>::type, D>(d, from.d);
-    in_assign< typename store_as<CE>::type, E>(e, from.e);
-    in_assign< typename store_as<CF>::type, F>(f, from.f);
-    in_assign< typename store_as<CG>::type, G>(g, from.g);
-    in_assign< typename store_as<CH>::type, H>(h, from.h);
-    in_assign< typename store_as<CI>::type, I>(i, from.i);
-    in_assign< typename store_as<CJ>::type, J>(j, from.j);
-    in_assign< typename store_as<CK>::type, K>(k, from.k);
-    in_assign< typename store_as<CL>::type, L>(l, from.l);
-    in_assign< typename store_as<CM>::type, M>(m, from.m);
-    in_assign< typename store_as<CN>::type, N>(n, from.n);
-    in_assign< typename store_as<CO>::type, O>(o, from.o);
-    in_assign< typename store_as<CP>::type, P>(p, from.p);
+    in_assign< typename store_as<CA>::type, typename store_ref<A>::type>(a, from.a);
+    in_assign< typename store_as<CB>::type, typename store_ref<B>::type>(b, from.b);
+    in_assign< typename store_as<CC>::type, typename store_ref<C>::type>(c, from.c);
+    in_assign< typename store_as<CD>::type, typename store_ref<D>::type>(d, from.d);
+    in_assign< typename store_as<CE>::type, typename store_ref<E>::type>(e, from.e);
+    in_assign< typename store_as<CF>::type, typename store_ref<F>::type>(f, from.f);
+    in_assign< typename store_as<CG>::type, typename store_ref<G>::type>(g, from.g);
+    in_assign< typename store_as<CH>::type, typename store_ref<H>::type>(h, from.h);
+    in_assign< typename store_as<CI>::type, typename store_ref<I>::type>(i, from.i);
+    in_assign< typename store_as<CJ>::type, typename store_ref<J>::type>(j, from.j);
+    in_assign< typename store_as<CK>::type, typename store_ref<K>::type>(k, from.k);
+    in_assign< typename store_as<CL>::type, typename store_ref<L>::type>(l, from.l);
+    in_assign< typename store_as<CM>::type, typename store_ref<M>::type>(m, from.m);
+    in_assign< typename store_as<CN>::type, typename store_ref<N>::type>(n, from.n);
+    in_assign< typename store_as<CO>::type, typename store_ref<O>::type>(o, from.o);
+    in_assign< typename store_as<CP>::type, typename store_ref<P>::type>(p, from.p);
   }
   void assign_to(ref_tuple<A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P> &to)
   {
     out_assign< typename store_as<CA>::type, typename store_ref<A>::type>(a, to.a);
-    out_assign< typename store_as<CB>::type, B>(b, to.b);
-    out_assign< typename store_as<CC>::type, C>(c, to.c);
-    out_assign< typename store_as<CD>::type, D>(d, to.d);
-    out_assign< typename store_as<CE>::type, E>(e, to.e);
-    out_assign< typename store_as<CF>::type, F>(f, to.f);
-    out_assign< typename store_as<CG>::type, G>(g, to.g);
-    out_assign< typename store_as<CH>::type, H>(h, to.h);
-    out_assign< typename store_as<CI>::type, I>(i, to.i);
-    out_assign< typename store_as<CJ>::type, J>(j, to.j);
-    out_assign< typename store_as<CK>::type, K>(k, to.k);
-    out_assign< typename store_as<CL>::type, L>(l, to.l);
-    out_assign< typename store_as<CM>::type, M>(m, to.m);
-    out_assign< typename store_as<CN>::type, N>(n, to.n);
-    out_assign< typename store_as<CO>::type, O>(o, to.o);
-    out_assign< typename store_as<CP>::type, P>(p, to.p);
+    out_assign< typename store_as<CB>::type, typename store_ref<B>::type>(b, to.b);
+    out_assign< typename store_as<CC>::type, typename store_ref<C>::type>(c, to.c);
+    out_assign< typename store_as<CD>::type, typename store_ref<D>::type>(d, to.d);
+    out_assign< typename store_as<CE>::type, typename store_ref<E>::type>(e, to.e);
+    out_assign< typename store_as<CF>::type, typename store_ref<F>::type>(f, to.f);
+    out_assign< typename store_as<CG>::type, typename store_ref<G>::type>(g, to.g);
+    out_assign< typename store_as<CH>::type, typename store_ref<H>::type>(h, to.h);
+    out_assign< typename store_as<CI>::type, typename store_ref<I>::type>(i, to.i);
+    out_assign< typename store_as<CJ>::type, typename store_ref<J>::type>(j, to.j);
+    out_assign< typename store_as<CK>::type, typename store_ref<K>::type>(k, to.k);
+    out_assign< typename store_as<CL>::type, typename store_ref<L>::type>(l, to.l);
+    out_assign< typename store_as<CM>::type, typename store_ref<M>::type>(m, to.m);
+    out_assign< typename store_as<CN>::type, typename store_ref<N>::type>(n, to.n);
+    out_assign< typename store_as<CO>::type, typename store_ref<O>::type>(o, to.o);
+    out_assign< typename store_as<CP>::type, typename store_ref<P>::type>(p, to.p);
   }
   virtual void printTo(std::ostream &os) const
   {

--- a/HippoMocksTest/CMakeLists.txt
+++ b/HippoMocksTest/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${PROJECT_NAME}
 	test_inparam.cpp
 	test_membermock.cpp
 	test_mi.cpp
+	test_move.cpp
 	test_nevercall.cpp
 	test_objectreturn.cpp
 	test_optional.cpp

--- a/HippoMocksTest/test_move.cpp
+++ b/HippoMocksTest/test_move.cpp
@@ -24,5 +24,5 @@ TEST (TestMove, checkMoveChecked)
     MockRepository mocks;
     INext *nextMock = mocks.Mock<INext>();
     mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
-	EXPECT_THROW(nextMock->doSomeThing("abcd"), HippoMocks::ExpectationException);
+	EXPECT_THROW(nextMock->doSomeThing("bc"), HippoMocks::ExpectationException);
 }

--- a/HippoMocksTest/test_move.cpp
+++ b/HippoMocksTest/test_move.cpp
@@ -1,10 +1,12 @@
 #include "hippomocks.h"
 #include "gtest/gtest.h"
 #include <string>
+#include <list>
 
 class INext {
 public:
-        virtual void doSomeThing(std::string&& arg) = 0;
+        virtual void f(std::string&& arg) = 0;
+        virtual void g(int i, std::list<int>&& j) = 0;
 };
 
 TEST (TestMove, checkMoveAccepted)
@@ -13,8 +15,8 @@ TEST (TestMove, checkMoveAccepted)
 
     MockRepository mocks;
     INext *nextMock = mocks.Mock<INext>();
-    mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
-    nextMock->doSomeThing("abcd");
+    mocks.ExpectCall(nextMock, INext::f).With(test1);
+    nextMock->f("abcd");
 }
 
 TEST (TestMove, checkMoveChecked)
@@ -23,7 +25,20 @@ TEST (TestMove, checkMoveChecked)
 
     MockRepository mocks;
     INext *nextMock = mocks.Mock<INext>();
-    mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
-	EXPECT_THROW(nextMock->doSomeThing("bc"), HippoMocks::ExpectationException);
-	mocks.reset();
+    mocks.ExpectCall(nextMock, INext::f).With(test1);
+    EXPECT_THROW(nextMock->f("bc"), HippoMocks::ExpectationException);
+    mocks.reset();
+}
+
+std::list<int> makeList()
+{
+  return { 1, 2, 3 };
+}
+
+TEST (TestMove, checkMoveTwoAccepted)
+{
+    MockRepository mocks;
+    INext *nextMock = mocks.Mock<INext>();
+    mocks.ExpectCall(nextMock, INext::g).With(1, makeList());
+    nextMock->g(1, { 1, 2, 3 });
 }

--- a/HippoMocksTest/test_move.cpp
+++ b/HippoMocksTest/test_move.cpp
@@ -5,18 +5,24 @@
 class INext {
 public:
         virtual void doSomeThing(std::string&& arg) = 0;
-        virtual int doSomeThingEasy(double i) = 0;
 };
 
-TEST (TestMove, checkMoveAssignment)
+TEST (TestMove, checkMoveAccepted)
 {
     std::string test1("abcd");
 
     MockRepository mocks;
     INext *nextMock = mocks.Mock<INext>();
     mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
-    mocks.ExpectCall(nextMock, INext::doSomeThingEasy).With(0.4).Return(2);
-    std::string value("abcd");
-    nextMock->doSomeThing(std::move(value));
-    nextMock->doSomeThingEasy(0.4);
+    nextMock->doSomeThing("abcd");
+}
+
+TEST (TestMove, checkMoveChecked)
+{
+    std::string test1("abcd");
+
+    MockRepository mocks;
+    INext *nextMock = mocks.Mock<INext>();
+    mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
+	EXPECT_THROW(nextMock->doSomeThing("abcd"), HippoMocks::ExpectationException);
 }

--- a/HippoMocksTest/test_move.cpp
+++ b/HippoMocksTest/test_move.cpp
@@ -25,4 +25,5 @@ TEST (TestMove, checkMoveChecked)
     INext *nextMock = mocks.Mock<INext>();
     mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
 	EXPECT_THROW(nextMock->doSomeThing("bc"), HippoMocks::ExpectationException);
+	mocks.reset();
 }

--- a/HippoMocksTest/test_move.cpp
+++ b/HippoMocksTest/test_move.cpp
@@ -1,0 +1,22 @@
+#include "hippomocks.h"
+#include "gtest/gtest.h"
+#include <string>
+
+class INext {
+public:
+        virtual void doSomeThing(std::string&& arg) = 0;
+        virtual int doSomeThingEasy(double i) = 0;
+};
+
+TEST (TestMove, checkMoveAssignment)
+{
+    std::string test1("abcd");
+
+    MockRepository mocks;
+    INext *nextMock = mocks.Mock<INext>();
+    mocks.ExpectCall(nextMock, INext::doSomeThing).With(test1);
+    mocks.ExpectCall(nextMock, INext::doSomeThingEasy).With(0.4).Return(2);
+    std::string value("abcd");
+    nextMock->doSomeThing(std::move(value));
+    nextMock->doSomeThingEasy(0.4);
+}


### PR DESCRIPTION
This PR adds support to mock interfaces that take rvalue references as parameters.

The usage is straightforward as shown in the added unit test.

The implementation required introducing a new helper `store_ref`, analog to the existing `store_as`.